### PR TITLE
fix chart

### DIFF
--- a/charts/customer_account/templates/_helpers.tpl
+++ b/charts/customer_account/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "cloudspace.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/customer_account/templates/eks-nodegroup.yaml
+++ b/charts/customer_account/templates/eks-nodegroup.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   forProvider:
     region: {{ .Values.region }}
-    version: {{ .Values.eks.eksVersion }}
+    version: "{{ .Values.eks.eksVersion }}"
     diskSize: {{ .Values.eks.eksDiskSize }}
     instanceTypes: 
       - {{ .Values.eks.nodeGroup.instanceTypes }}

--- a/charts/customer_account/templates/eks.yaml
+++ b/charts/customer_account/templates/eks.yaml
@@ -19,11 +19,18 @@ spec:
         - name: "{{ include "cloudspace.name" .}}-ubix-subnet2"
       securityGroupIdRefs:
         - name: "{{ include "cloudspace.name" .}}-ubix-cluster-sg"
-    version: {{ .Values.eks.eksVersion }}
+    version: "{{ .Values.eks.eksVersion  }}"
   writeConnectionSecretToRef:
     name: "{{ include "cloudspace.name" .}}-cluster-conn"
-    namespace: {{ .Values.customerName }}
+    namespace: {{ include "cloudspace.name" .}}
   providerConfigRef:
     name: "{{ include "cloudspace.name" .}}-awsaccount-crossplane"
     policy:
       resolve: Always
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "cloudspace.name" .}}
+  labels:
+    name: {{ include "cloudspace.name" .}}

--- a/charts/customer_account/templates/nat-gateways.yaml
+++ b/charts/customer_account/templates/nat-gateways.yaml
@@ -8,9 +8,8 @@ spec:
   forProvider:
     region: {{ .Values.region }}
     connectivityType: {{ .Values.natGateway.connectivityType }} 
-    allocationIdSelector:
-      matchLabels:
-        name: "{{ include "cloudspace.name" .}}-eip1"
+    allocationIdRef:
+      name: "{{ include "cloudspace.name" .}}-eip1"
     subnetIdRef:
       name: "{{ include "cloudspace.name" .}}-ubix-subnet1"
   providerConfigRef:
@@ -26,11 +25,10 @@ metadata:
     {{- include "cloudspace.labels" . | nindent 4 }}
 spec:
   forProvider:
-    region: 
+    region: {{ .Values.region }}
     connectivityType: {{ .Values.natGateway.connectivityType }} 
-    allocationIdSelector:
-      matchLabels:
-        name: "{{ include "cloudspace.name" .}}-eip2"
+    allocationIdRef:
+      name: "{{ include "cloudspace.name" .}}-eip2"
     subnetIdRef:
       name: "{{ include "cloudspace.name" .}}-ubix-subnet2"
   providerConfigRef:
@@ -41,7 +39,7 @@ spec:
 apiVersion: ec2.aws.crossplane.io/v1beta1
 kind: Address
 metadata:
-  name: "{{ include "cloudspace.name" .}}-eip1"
+  name: {{ include "cloudspace.name" .}}-eip1
   labels:
     {{- include "cloudspace.labels" . | nindent 4 }}
 spec:
@@ -55,7 +53,7 @@ spec:
 apiVersion: ec2.aws.crossplane.io/v1beta1
 kind: Address
 metadata:
-  name: "{{ include "cloudspace.name" .}}-eip2"
+  name: {{ include "cloudspace.name" .}}-eip2
   labels:
     {{- include "cloudspace.labels" . | nindent 4 }}
 spec:

--- a/charts/customer_account/templates/securitygroup.yaml
+++ b/charts/customer_account/templates/securitygroup.yaml
@@ -9,18 +9,18 @@ spec:
     region: {{ .Values.region }}
     vpcIdRef:
       name: "{{ include "cloudspace.name" .}}-ubix-vpc"  
-    groupName: "{{ include "cloudspace.name" .}}-ekscluster-sg"
+    groupName: "{{ include "cloudspace.name" .}}-ubix-cluster-sg"
     description: Cluster communication with worker nodes
     ingress:
       - fromPort: {{ .Values.securityGroup.ingress.fromPort }}
         toPort: {{ .Values.securityGroup.ingress.toPort }}
-        ipProtocol: {{ .Values.securityGroup.ingress.ipProtocol }}
+        ipProtocol: "{{ .Values.securityGroup.ingress.ipProtocol }}"
         ipRanges:
           - cidrIp: {{ .Values.securityGroup.ingress.ipRanges.cidrIp }}
     egress:
       - fromPort: {{ .Values.securityGroup.egress.fromPort }}
         toPort: {{ .Values.securityGroup.egress.toPort }}
-        ipProtocol: {{ .Values.securityGroup.egress.ipProtocol }}
+        ipProtocol: "{{ .Values.securityGroup.egress.ipProtocol }}"
         ipRanges:
           - cidrIp: {{ .Values.securityGroup.egress.ipRanges.cidrIp }}
   providerConfigRef:

--- a/charts/customer_account/templates/subnets.yaml
+++ b/charts/customer_account/templates/subnets.yaml
@@ -1,7 +1,7 @@
 apiVersion: ec2.aws.crossplane.io/v1beta1
 kind: Subnet
 metadata:
-  name: "{{ include "cloudspace.name" .}}-ubix-subnet1"
+  name: {{ include "cloudspace.name" .}}-ubix-subnet1
   labels:
     {{- include "cloudspace.labels" . | nindent 4 }}
 spec:
@@ -20,7 +20,7 @@ spec:
 apiVersion: ec2.aws.crossplane.io/v1beta1
 kind: Subnet
 metadata:
-  name: "{{ include "cloudspace.name" .}}-ubix-subnet2"
+  name: {{ include "cloudspace.name" .}}-ubix-subnet2
   labels:
     {{- include "cloudspace.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Fixed multiple minor issues that prevented the chart from being deployed flawlessly.

- Namespace creation
- Release name to deploy multiple customers
- Reference to subnets upgraded matching the new CRD
- Missing region in nat gateway
- Removed doublequotes when not required