### PR TITLE
Add Karpenter role AmazonSSMManagedInstanceCore

### DIFF
--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -1859,9 +1859,10 @@ spec:
       spec:
         forProvider:
           policyArn: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-          role: "patch-me"
+          role: #patchme
     patches:
-    - fromFieldPath: spec.id
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
       toFieldPath: metadata.name
       transforms:
       - type: string

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -1852,6 +1852,28 @@ spec:
       fromFieldPath: status.id
       toFieldPath: spec.providerConfigRef.name
 
+  - name: karpenter-ssm-managed-instance-policy
+    base:
+      apiVersion: iam.aws.upbound.io/v1beta1
+      kind: RolePolicyAttachment
+      spec:
+        forProvider:
+          policyArn: arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+          role: "patch-me"
+    patches:
+    - fromFieldPath: spec.id
+      toFieldPath: metadata.name
+      transforms:
+      - type: string
+        string:
+          fmt: '%s-karpenter-ssm-managed-instance'
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.karpenterClusterRoleName
+      toFieldPath: spec.forProvider.role
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.id
+      toFieldPath: spec.providerConfigRef.name
+
   - name: karpenter-cni-policy
     base:
       apiVersion: iam.aws.upbound.io/v1beta1


### PR DESCRIPTION
Adding the following policy to karpenter cluster role, it is required for the node to succeed in the registration to the cluster

![image](https://user-images.githubusercontent.com/43704198/232760035-5e786836-a67d-47db-9af2-6541a4ae4fdb.png)
