### PR TITLE
add postgres operator role and policy

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.9.31
+version: 0.9.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -2319,6 +2319,62 @@ spec:
 # # IAM Roles
 # ########
 
+  - name: postgres-operator-s3-backups-role
+    base:
+      apiVersion: iam.aws.upbound.io/v1beta1
+      kind: Role
+      metadata:
+        annotations:
+          crossplane.io/external-name: postgres-pod-role
+      spec:
+        forProvider:
+          assumeRolePolicy: ""
+    patches:
+      - type: FromCompositeFieldPath
+        fromFieldPath: spec.id
+        toFieldPath: metadata.name
+        transforms:
+          - type: string
+            string:
+              fmt: "%s-postgres-operator"
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.id
+        toFieldPath: spec.providerConfigRef.name
+      - type: CombineFromComposite
+        toFieldPath: spec.forProvider.assumeRolePolicy
+        combine:
+          variables:
+            - fromFieldPath: status.id
+            - fromFieldPath: status.clusterOIDC
+            - fromFieldPath: status.clusterOIDC
+            - fromFieldPath: status.clusterOIDC
+          strategy: string
+          string:
+            fmt: |
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Sid": "",
+                    "Effect": "Allow",
+                    "Principal": {
+                      "Federated": "arn:aws:iam::%s:oidc-provider/%s"
+                    },
+                    "Action": "sts:AssumeRoleWithWebIdentity",
+                    "Condition": {
+                      "StringEquals": {
+                          "%s:sub": [
+                          "system:serviceaccount:addons:postgres-operator"],
+                          "%s:aud": "sts.amazonaws.com"
+                      }
+                    }
+                  }
+                ]
+              }
+      - type: ToCompositeFieldPath
+        fromFieldPath: status.atProvider.id
+        toFieldPath: status.postgresOperatorRoleName
+
   - name: mlflow-role
     base:
       apiVersion: iam.aws.upbound.io/v1beta1
@@ -3034,6 +3090,58 @@ spec:
 # # IAM Policies
 # ########
 
+  - name: postgres-operator-s3-backups-policy
+    base:
+      apiVersion: iam.aws.upbound.io/v1beta1
+      kind: Policy
+      metadata:
+        annotations:
+          crossplane.io/external-name: SpiloS3Access
+      spec:
+        forProvider:
+          policy: #patchme
+    patches:
+    - type: CombineFromComposite
+      toFieldPath: spec.forProvider.policy
+      combine:
+        variables:
+        - fromFieldPath: status.id
+        - fromFieldPath: spec.parameters.region
+        - fromFieldPath: spec.id
+        - fromFieldPath: status.id
+        - fromFieldPath: spec.parameters.region
+        - fromFieldPath: spec.id
+        strategy: string
+        string:
+          fmt: |
+              {
+                  "Statement": [
+                      {
+                          "Action": [
+                              "s3:*"
+                          ],
+                          "Effect": "Allow",
+                          "Resource": [
+                              "arn:aws:s3:::postgres-backups-%s-%s-%s",
+                              "arn:aws:s3:::postgres-backups-%s-%s-%s/*"
+                          ]
+                      }
+                  ],
+                  "Version": "2012-10-17"
+              }
+    - fromFieldPath: spec.id
+      toFieldPath: metadata.name
+      transforms:
+        - type: string
+          string:
+            fmt: "%s-postgres-operator-s3-backups-full-access"
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.id
+      toFieldPath: spec.providerConfigRef.name
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.atProvider.id
+      toFieldPath: status.postgresOperatorS3PolicyArn
+
   - name: ingestion-artifacts-s3-policy
     base:
       apiVersion: iam.aws.upbound.io/v1beta1
@@ -3436,6 +3544,31 @@ spec:
 # ########
 # # IAM Policy Attachments
 # ########
+
+  - name: postgres-operator-s3-backups-policy-attachment
+    base:
+      apiVersion: iam.aws.upbound.io/v1beta1
+      kind: RolePolicyAttachment
+      spec:
+        forProvider:
+          policyArn: #patchme
+          role: #patchme
+    patches:
+      - fromFieldPath: spec.id
+        toFieldPath: metadata.name
+        transforms:
+          - type: string
+            string:
+              fmt: "%s-postgres-operator-s3-backups"
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.postgresOperatorS3PolicyArn
+        toFieldPath: spec.forProvider.policyArn
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.postgresOperatorRoleName
+        toFieldPath: spec.forProvider.role
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.id
+        toFieldPath: spec.providerConfigRef.name
 
   - name: mlflow-artifacts-policy-attachment
     base:

--- a/charts/child-account-composition/templates/definition.yaml
+++ b/charts/child-account-composition/templates/definition.yaml
@@ -190,6 +190,9 @@ spec:
               mlflowRoleName:
                 description: Role to give s3 access to the cluster
                 type: string
+              postgresOperatorRoleName:
+                description: Role that makes sure Postgres can send compressed WAL files to the given S3 bucket
+                type: string
               dataServiceRoleName:
                 description: Role to give s3 access to the cluster
                 type: string
@@ -207,6 +210,9 @@ spec:
                 type: string
               mlflowArtifactsS3PolicyArn:
                 description: Policy to give s3 access to the cluster
+                type: string
+              postgresOperatorS3PolicyArn:
+                description: Policy to give s3 access to the cluster, bucket that is used for postgres s3 backups
                 type: string
               externalDnsRoleArn:
                 description: Policy to allow external dns to work


### PR DESCRIPTION
Adding IAM role, Policy and PolicyAttachment for postgres operator based on [the following documentation](https://github.com/zalando/postgres-operator/blob/master/docs/administrator.md#using-aws-s3-or-compliant-services)


### Using AWS S3 or compliant services

When using AWS you have to reference the S3 backup path, the IAM role and the
AWS region in the configuration.

**postgres-operator ConfigMap**

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: postgres-operator
data:
  aws_region: eu-central-1
  kube_iam_role: postgres-pod-role
  wal_s3_bucket: your-backup-path
```

**OperatorConfiguration**

```yaml
apiVersion: "acid.zalan.do/v1"
kind: OperatorConfiguration
metadata:
  name: postgresql-operator-configuration
configuration:
  aws_or_gcp:
    aws_region: eu-central-1
    kube_iam_role: postgres-pod-role
    wal_s3_bucket: your-backup-path
```

The referenced IAM role should contain the following privileges to make sure
Postgres can send compressed WAL files to the given S3 bucket:

```yaml
  PostgresPodRole:
    Type: "AWS::IAM::Role"
    Properties:
      RoleName: "postgres-pod-role"
      Path: "/"
      Policies:
        - PolicyName: "SpiloS3Access"
          PolicyDocument:
            Version: "2012-10-17"
            Statement:
              - Action: "s3:*"
                Effect: "Allow"
                Resource:
                  - "arn:aws:s3:::your-backup-path"
                  - "arn:aws:s3:::your-backup-path/*"
```

This should produce the following settings for the essential environment
variables:

```bash
AWS_ENDPOINT='https://s3.eu-central-1.amazonaws.com:443'
WALE_S3_ENDPOINT='https+path://s3.eu-central-1.amazonaws.com:443'
WALE_S3_PREFIX=$WAL_S3_BUCKET/spilo/{WAL_BUCKET_SCOPE_PREFIX}{SCOPE}{WAL_BUCKET_SCOPE_SUFFIX}/wal/{PGVERSION}
```