### PR TITLE
Adding data-lineage missing web env vars

### DIFF
--- a/charts/data-lineage/Chart.yaml
+++ b/charts/data-lineage/Chart.yaml
@@ -14,4 +14,4 @@ name: data-lineage
 sources:
   - https://github.com/MarquezProject/marquez
   - https://marquezproject.github.io/marquez/
-version: 0.35.0
+version: 0.35.1

--- a/charts/data-lineage/templates/web/deployment.yaml
+++ b/charts/data-lineage/templates/web/deployment.yaml
@@ -42,6 +42,19 @@ spec:
               value: {{ include "common.names.fullname" . }}
             - name: MARQUEZ_PORT
               value: {{ .Values.service.port | quote }}
+            - name: POSTGRES_HOST
+              value: {{ include "marquez.database.host" . | quote }}
+            - name: POSTGRES_PORT
+              value: {{ include "marquez.database.port" . | quote }}
+            - name: POSTGRES_DB
+              value: {{ include "marquez.database.name" . | quote }}
+            - name: POSTGRES_USER
+              value: {{ include "marquez.database.user" . | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "marquez.postgresql.secretName" . }}
+                  key: {{ include "marquez.database.existingsecret.key" . }}
           {{- if .Values.web.resources }}
           resources: {{- toYaml .Values.web.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Adding env vars to the web deployment that are going to fix the failing pod
![image](https://github.com/Ubix/ubix-charts/assets/43704198/d13bcde6-6c71-40c6-9edb-9a3730e30907)

This error is produced by not having the env vars defined and looks like we moved from a development configuration to a production configuration where the postgresql db is not in the localhost.

Related commit: https://github.com/Ubix/data-lineage/commit/79bd211dc6f95c6775df7fa2ea05fed7fdead135