### PR TITLE
Fix Composition ALB Policy

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.10.35
+version: 0.10.36
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -3389,18 +3389,7 @@ spec:
           crossplane.io/external-name: AmazonEKS_AWS_Load_Balancer_Controller
       spec:
         forProvider:
-          policy: #patchme
-    patches:
-      - type: CombineFromComposite
-        toFieldPath: spec.forProvider.policy
-        policy:
-          fromFieldPath: Required
-        combine:
-          variables:
-          - fromFieldPath: status.id
-          strategy: string
-          string:
-            fmt: |
+          policy: |
                 {
                     "Statement": [
                         {
@@ -3624,6 +3613,7 @@ spec:
                     ],
                     "Version": "2012-10-17"
                 }
+    patches:
       - fromFieldPath: spec.id
         toFieldPath: metadata.name
         transforms:


### PR DESCRIPTION
Fixing the following error:

```
Events:
  Type     Reason                         Age                     From                                             Message
  ----     ------                         ----                    ----                                             -------
  Warning  CannotObserveExternalResource  2m52s (x164 over 168m)  managed/iam.aws.upbound.io/v1beta1, kind=policy  cannot run refresh: refresh failed: "policy" contains an invalid JSON policy: invalid character '%!'(MISSING) after top-level value, at byte offset 7758:
```