### PR TITLE
add ACM to ChildAccount

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.10.36
+version: 0.10.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -5123,3 +5123,77 @@ spec:
     - type: FromCompositeFieldPath
       fromFieldPath: status.id
       toFieldPath: spec.providerConfigRef.name
+
+###
+# ACM DNS configuration
+###
+
+  - name: child-account-acm-certificate
+    base:
+      apiVersion: acm.aws.upbound.io/v1beta1
+      kind: Certificate
+      metadata:
+        labels:
+          child-account-acm-certificate: #patched
+      spec:
+        forProvider:
+          region: #patched
+          domainName: #patched
+          validationMethod: DNS
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
+      toFieldPath: metadata.name
+      transforms:
+        - type: string
+          string:
+            fmt: '%s-child-account-acm-certificate'
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.region
+      toFieldPath: spec.forProvider.region
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
+      toFieldPath: spec.forProvider.domainName
+      transforms:
+        - type: string
+          string:
+            fmt: '*.%s.ubix.io'
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.atProvider.domainValidationOptions.resourceRecordValue
+      toFieldPath: status.ACMValidationRecordFqdns
+    - type: ToCompositeFieldPath
+      fromFieldPath: status.atProvider.arn
+      toFieldPath: status.ACMArn
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.id
+      toFieldPath: spec.providerConfigRef.name
+
+  - name: child-account-acm-certificate-validation
+    base:
+      apiVersion: acm.aws.upbound.io/v1beta1
+      kind: CertificateValidation
+      spec:
+        forProvider:
+          region: #patched
+          certificateArn: #patched
+          validationRecordFqdns: #patched
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
+      toFieldPath: metadata.name
+      transforms:
+        - type: string
+          string:
+            fmt: '%s-child-account-acm-certificate'
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.parameters.region
+      toFieldPath: spec.forProvider.region
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.ACMValidationRecordFqdns
+      toFieldPath: spec.forProvider.validationRecordFqdns[0]
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.ACMArn
+      toFieldPath: spec.forProvider.certificateArn
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.id
+      toFieldPath: spec.providerConfigRef.name

--- a/charts/child-account-composition/templates/definition.yaml
+++ b/charts/child-account-composition/templates/definition.yaml
@@ -250,6 +250,12 @@ spec:
               ebsKmsArn:
                 description: EBS csi driver KMS key
                 type: string
+              ACMValidationRecordFqdns:
+                description: List of FQDNs that implement the validation. Only valid for DNS validation method ACM certificates.
+                type: string
+              ACMArn:
+                description: ARN of the certificate that is being validated.
+                type: string
     additionalPrinterColumns:
     - name: AWSAccountID
       type: string


### PR DESCRIPTION
Adding ACM to Child Accounts, this resource will create the TLS Certificate that will be used at the ALB / WAF attached to the ingresses