### PR TITLE
fix composition-instance chart minNodeCount

### DIFF
--- a/charts/composition-instance/Chart.yaml
+++ b/charts/composition-instance/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/composition-instance/templates/compositioninstance.yaml
+++ b/charts/composition-instance/templates/compositioninstance.yaml
@@ -19,7 +19,7 @@ spec:
   eks:
     version: {{ quote .Values.spec.eks.version }}
     nodeSize: {{ .Values.spec.eks.nodeSize }}
-    minNodeCount: {{ .Values.spec.eks.nodeSize }}
+    minNodeCount: {{ .Values.spec.eks.minNodeCount }}
     maxNodeCount: {{ .Values.spec.eks.maxNodeCount }}
     desiredNodeCount: {{ .Values.spec.eks.desiredNodeCount }}
     diskSize: {{ .Values.spec.eks.diskSize }}


### PR DESCRIPTION
Fixing the following error on Child Accounts deployments

````
error validating data: ValidationError(ChildAccountClaim.spec.eks.minNodeCount): invalid type for resources.cloudspace.v1alpha1.ChildAccountClaim.spec.eks.minNodeCount: got "string", expected "integer"
````
