### PR TITLE
feat/CLOUD 63 provision grafana data sources

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.15.12
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -5679,7 +5679,7 @@ spec:
 # Grafana Resources
 #####
 
-  - name: grafana-data-srouces
+  - name: grafana-data-sources
     base:
       apiVersion: kubernetes.crossplane.io/v1alpha1
       kind: Object

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -5673,6 +5673,112 @@ spec:
         toFieldPath: spec.forProvider.manifest.stringData.config
         policy:
           fromFieldPath: Required
+
+
+#####
+# Grafana Resources
+#####
+
+  - name: grafana-data-srouces
+    base:
+      apiVersion: kubernetes.crossplane.io/v1alpha1
+      kind: Object
+      spec:
+        forProvider:
+          manifest:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: # patched
+              namespace: addons
+              labels:
+                grafana_datasource: "1"
+            # stringData:
+              # name: # patched
+              # server: # patched
+              # config:
+              #   awsAuthConfig:
+              #       clusterName: # patched
+              #       roleARN: # patched
+            type: Opaque
+        providerConfigRef:
+          name: kubernetes-provider
+    patches:
+      - type: FromCompositeFieldPath
+        fromFieldPath: spec.id
+        toFieldPath: metadata.name
+        transforms:
+          - type: string
+            string:
+              fmt: "%s-grafana-data-sources"
+      - type: FromCompositeFieldPath
+        fromFieldPath: spec.id
+        toFieldPath: spec.forProvider.manifest.metadata.name
+        transforms:
+          - type: string
+            string:
+              fmt: "%s-grafana-data-sources"
+      - type: CombineFromComposite
+        policy:
+          fromFieldPath: Required
+        toFieldPath: spec.forProvider.manifest.stringData
+        combine:
+          variables:
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+            - fromFieldPath: spec.id
+          strategy: string
+          string:
+            fmt: |
+              %s.yaml: |
+                apiVersion: 1
+                deleteDatasources:
+                - name: Mimir %s
+                - name: Tempo %s
+                - name: Loki %s
+                datasources:
+                - name: Mimir %s
+                  type: prometheus
+                  typeName: Prometheus
+                  typeLogoUrl: https://grafana.com/static/img/logos/logo-mimir.svg
+                  access: proxy
+                  url: http://mimir-gateway/prometheus
+                  basicAuth: true
+                  basicAuthUser: ${{ .Values.mimir.user }}
+                  jsonData:
+                    httpHeaderName1: 'X-Scope-OrgID'
+                  secureJsonData:
+                    httpHeaderValue1: '%s'
+                    basicAuthPassword: ${{ .Values.mimir.password }}
+                  isDefault: false
+                  readOnly: true
+                - name: Tempo %s
+                  type: tempo
+                  access: proxy
+                  url: http://tempo-gateway
+                  basicAuth: true
+                  basicAuthUser: ${{ .Values.tempo.user }}
+                  secureJsonData:
+                    basicAuthPassword: ${{ .Values.tempo.password }}
+                  isDefault: false
+                  readOnly: true
+                - name: Loki %s
+                  type: loki
+                  url: http://loki-gateway
+                  baseAuth: true
+                  basicAuthUser: ${{ .Values.loki.user }}
+                  secureJsonData:
+                    basicAuthPassword: ${{ .Values.loki.password }}
+                  isDefault: false
+                  readOnly: true
+        policy:
+          fromFieldPath: Required
+
 #####
 # Route53
 #####
@@ -6719,7 +6825,7 @@ spec:
     - type: FromCompositeFieldPath
       fromFieldPath: status.id
       toFieldPath: spec.providerConfigRef.name
-  
+
   - name: aws-lb-controller-role-policy
     base:
       apiVersion: iam.aws.upbound.io/v1beta1

--- a/charts/child-account-composition/values.yaml
+++ b/charts/child-account-composition/values.yaml
@@ -1,3 +1,12 @@
 backofficeArgocdRoleArn: arn:aws:iam::882490700787:role/argocd-server
 zoneId: "Z2FIL4FICDFU9O" # Add Parent Zone ID
 parentId: "ou-8jat-sv0412tm" # Add Parent OU ID
+mimir:
+  user: "required"
+  password: "required"
+tempo:
+  user: "required"
+  password: "required"
+loki:
+  user: "required"
+  password: "required"


### PR DESCRIPTION
- feat(grafana): add secret creation to provision grafana datasources for new accounts with loki, mimir and tempo
- feat(grafana): add values to input mimir, tempo and loki credentials
- chore(child-account-composition): bump chart version
