### PR TITLE
fix/CLOUD 63 secret formatting 1

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 
-version: 0.16.3
+version: 0.16.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -5873,73 +5873,12 @@ spec:
             - fromFieldPath: spec.id
           strategy: string
           string:
-            fmt: |
-              {
-                "%s.yaml": {
-                  "apiVersion": 1,
-                  "deleteDatasources": [
-                    {
-                      "name": "Mimir %s"
-                    },
-                    {
-                      "name": "Tempo %s"
-                    },
-                    {
-                      "name": "Loki %s"
-                    }
-                  ],
-                  "datasources": [
-                    {
-                      "name": "Mimir %s",
-                      "type": "prometheus",
-                      "typeName": "Prometheus",
-                      "typeLogoUrl": "https://grafana.com/static/img/logos/logo-mimir.svg",
-                      "access": "proxy",
-                      "url": "http://mimir-gateway/prometheus",
-                      "basicAuth": true,
-                      "basicAuthUser": "{{ .Values.mimir.user }}",
-                      "jsonData": {
-                        "httpHeaderName1": "X-Scope-OrgID"
-                      },
-                      "secureJsonData": {
-                        "httpHeaderValue1": "%s",
-                        "basicAuthPassword": "{{ .Values.mimir.password }}"
-                      },
-                      "isDefault": false,
-                      "readOnly": true
-                    },
-                    {
-                      "name": "Tempo %s",
-                      "type": "tempo",
-                      "access": "proxy",
-                      "url": "http://tempo-gateway",
-                      "basicAuth": true,
-                      "basicAuthUser": "{{ .Values.tempo.user }}",
-                      "secureJsonData": {
-                        "basicAuthPassword": "{{ .Values.tempo.password }}"
-                      },
-                      "isDefault": false,
-                      "readOnly": true
-                    },
-                    {
-                      "name": "Loki %s",
-                      "type": "loki",
-                      "url": "http://loki-gateway",
-                      "baseAuth": true,
-                      "basicAuthUser": "{{ .Values.loki.user }}",
-                      "secureJsonData": {
-                        "basicAuthPassword": "{{ .Values.loki.password }}"
-                      },
-                      "isDefault": false,
-                      "readOnly": true
-                    }
-                  ]
-              }
+            fmt: '{"%s.yaml": "apiVersion: 1\ndeleteDatasources:\n- name: Mimir %s\n- name: Tempo %s\n- name: Loki %s\ndatasources:\n- name: Mimir %s\n  type: prometheus\n  typeName: Prometheus\n  typeLogoUrl: https://grafana.com/static/img/logos/logo-mimir.svg\n  access: proxy\n  url: http://mimir-gateway/prometheus\n  basicAuth: true\n  basicAuthUser: {{ .Values.mimir.user }}\n  jsonData:\n    httpHeaderName1: \"X-Scope-OrgID\"\n  secureJsonData:\n    httpHeaderValue1: \"%s\"\n    basicAuthPassword: {{ .Values.mimir.password }}\n  isDefault: false\n  readOnly: true\n- name: Tempo %s\n  type: tempo\n  access: proxy\n  url: http://tempo-gateway\n  basicAuth: true\n  basicAuthUser: {{ .Values.tempo.user }}\n  secureJsonData:\n    basicAuthPassword: {{ .Values.tempo.password }}\n  isDefault: false\n  readOnly: true\n- name: Loki %s\n  type: loki\n  url: http://loki-gateway\n  baseAuth: true\n  basicAuthUser: {{ .Values.loki.user }}\n  secureJsonData:\n    basicAuthPassword: {{ .Values.loki.password }}\n  isDefault: false\n  readOnly: true\n"}'
         transforms:
-          - type: convert
-            convert:
-              toType: object
-              format: json
+        - type: convert
+          convert:
+            toType: object
+            format: json
         policy:
           fromFieldPath: Required
 

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -5873,6 +5873,9 @@ spec:
             - fromFieldPath: spec.id
           strategy: string
           string:
+            # this section needs to be like this due to crossplane limitations.
+            # to edit the grafana yaml copy the string value and use a json to yaml converter
+            # then copy it back using the single line json format
             fmt: '{"%s.yaml": "apiVersion: 1\ndeleteDatasources:\n- name: Mimir %s\n- name: Tempo %s\n- name: Loki %s\ndatasources:\n- name: Mimir %s\n  type: prometheus\n  typeName: Prometheus\n  typeLogoUrl: https://grafana.com/static/img/logos/logo-mimir.svg\n  access: proxy\n  url: http://mimir-gateway/prometheus\n  basicAuth: true\n  basicAuthUser: {{ .Values.mimir.user }}\n  jsonData:\n    httpHeaderName1: \"X-Scope-OrgID\"\n  secureJsonData:\n    httpHeaderValue1: \"%s\"\n    basicAuthPassword: {{ .Values.mimir.password }}\n  isDefault: false\n  readOnly: true\n- name: Tempo %s\n  type: tempo\n  access: proxy\n  url: http://tempo-gateway\n  basicAuth: true\n  basicAuthUser: {{ .Values.tempo.user }}\n  secureJsonData:\n    basicAuthPassword: {{ .Values.tempo.password }}\n  isDefault: false\n  readOnly: true\n- name: Loki %s\n  type: loki\n  url: http://loki-gateway\n  baseAuth: true\n  basicAuthUser: {{ .Values.loki.user }}\n  secureJsonData:\n    basicAuthPassword: {{ .Values.loki.password }}\n  isDefault: false\n  readOnly: true\n"}'
         transforms:
         - type: convert


### PR DESCRIPTION
- fix(child-account-composition): change patch to a single line json to overcome crossplane limitations
- docs(child-account-composition): add comments explaining the reason of the workaround
- chore(child-account-composition): bump chart version
