### PR TITLE
chore(child-account-composition): Add maxSessionDuration for ds-backend role

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.17.20
+version: 0.17.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.17.19
+version: 0.17.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,9 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-
 version: 0.17.21
-
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -6714,7 +6714,7 @@ spec:
                 - PUT
               allowedOrigins:
                 - patchme
-              maxAgeSeconds: 6000
+              maxAgeSeconds: 86400
           region: #patchme
     patches:
     - type: FromCompositeFieldPath

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -3478,6 +3478,7 @@ spec:
       spec:
         forProvider:
           assumeRolePolicy: ""
+          maxSessionDuration: 43200
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec.id
@@ -6714,7 +6715,7 @@ spec:
                 - PUT
               allowedOrigins:
                 - patchme
-              maxAgeSeconds: 86400
+              maxAgeSeconds: 43200
           region: #patchme
     patches:
     - type: FromCompositeFieldPath

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -3528,6 +3528,7 @@ spec:
       spec:
         forProvider:
           assumeRolePolicy: ""
+          maxSessionDuration: 43200
     patches:
     - type: FromCompositeFieldPath
       fromFieldPath: spec.id


### PR DESCRIPTION
- [CLOUD-164] chore(cac): Increase ingestion s3 CORS maxAgeSeconds to 24hrs
- Set maxSessionDuration to 12hrs
- chore(child-account-composition): Add maxSessionDuration for ds-backend role


[CLOUD-164]: https://ubixlabs.atlassian.net/browse/CLOUD-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ