### PR TITLE
feat/subnet tagging

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.21.13
+version: 0.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -900,6 +900,7 @@ spec:
           mapPublicIpOnLaunch: true
           tags:
             kubernetes.io/role/elb: "1"
+            subnet-type: public
       providerConfigRef:
         policy:
           resolve: "Always"
@@ -946,6 +947,7 @@ spec:
           mapPublicIpOnLaunch: true
           tags:
             kubernetes.io/role/elb: "1"
+            subnet-type: public
       providerConfigRef:
         policy:
           resolve: "Always"
@@ -992,6 +994,7 @@ spec:
           mapPublicIpOnLaunch: true
           tags:
             kubernetes.io/role/elb: "1"
+            subnet-type: public
       providerConfigRef:
         policy:
           resolve: "Always"
@@ -1037,6 +1040,7 @@ spec:
             name: #patched
           tags:
             karpenter.sh/discovery: #patchme
+            subnet-type: private
             kubernetes.io/role/internal-elb: "1"
       providerConfigRef:
         policy:
@@ -1087,6 +1091,7 @@ spec:
           tags:
             karpenter.sh/discovery: #patchme
             kubernetes.io/role/internal-elb: "1"
+            subnet-type: private
       providerConfigRef:
         policy:
           resolve: "Always"
@@ -1136,6 +1141,7 @@ spec:
           tags:
             karpenter.sh/discovery: #patchme
             kubernetes.io/role/internal-elb: "1"
+            subnet-type: private
       providerConfigRef:
         policy:
           resolve: "Always"


### PR DESCRIPTION
- **feat(child-account-composition): create subnet type tag for karpenter selection**
- **chore(child-account-composition): bump chart version**
