### PR TITLE
feat/CLOUD 365 karpenter standardization

### DIFF
--- a/charts/child-account-composition/Chart.yaml
+++ b/charts/child-account-composition/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.22.0
+version: 0.22.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -133,6 +133,7 @@ spec:
         forProvider:
           tags:
             karpenter.sh/discovery: #patchme
+            worker-security-group: default
           description: Security group for all nodes in the cluster
           name: #patchme
           region: #patchme

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -2291,7 +2291,7 @@ spec:
       transforms:
       - type: string
         string:
-          fmt: '%s-karpenter'
+          fmt: '%s-karpenter-1'
     - type: FromCompositeFieldPath
       fromFieldPath: spec.id
       toFieldPath: spec.forProvider.roleRef.name

--- a/charts/child-account-composition/templates/composition.yaml
+++ b/charts/child-account-composition/templates/composition.yaml
@@ -2272,6 +2272,37 @@ spec:
       fromFieldPath: status.id
       toFieldPath: spec.providerConfigRef.name
 
+  - name: karpenter-instance-profile-1
+    base:
+      apiVersion: iam.aws.upbound.io/v1beta1
+      kind: InstanceProfile
+      metadata:
+        annotations:
+          crossplane.io/external-name: karpenter
+      spec:
+        deletionPolicy: Orphan
+        forProvider:
+          roleRef:
+            name: #patchme
+    patches:
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
+      toFieldPath: metadata.name
+      transforms:
+      - type: string
+        string:
+          fmt: '%s-karpenter'
+    - type: FromCompositeFieldPath
+      fromFieldPath: spec.id
+      toFieldPath: spec.forProvider.roleRef.name
+      transforms:
+      - type: string
+        string:
+          fmt: '%s-karpenter-cluster'
+    - type: FromCompositeFieldPath
+      fromFieldPath: status.id
+      toFieldPath: spec.providerConfigRef.name
+
 # ########
 # # IAM Roles
 # ########


### PR DESCRIPTION
- **chore(child-account-composition): add static tag for security group selection**
- **chore(child-account-composition): create new instance profile with static external name**
- **chore(child-account-composition): add sulfix to resource name to avoid conflict with old one**
- **chore(child-account-composition): bump chart version**
